### PR TITLE
gitignore: add a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.swp


### PR DESCRIPTION
Add a .gitignore and ignore __pycache__/ and vim's swap files.

Signed-off-by: Johannes Thumshirn <jth@kernel.org>