### PR TITLE
New Test: check if a method is implemented for each static page

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,30 @@
+# .coveragerc to control coverage.py
+[run]
+branch = True
+omit=
+	test*.py
+	setup.py
+	__init__.py
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:
+
+ignore_errors = True
+
+[html]
+directory = coverage_html_report

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
 __pycache__
 *.swp
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ setup:
 
 test:
 	${PYCODESTYLE} *.py
-#	${PYTHON} -m pytest
+	${PYTHON} -m pytest --cov-report=term --cov=app tests/ 
 
 clean:
 	@echo "cleaning"

--- a/tests/test_static_pages.py
+++ b/tests/test_static_pages.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: GPL-3.0
+import app
+
+import os
+import sys
+
+import pytest
+import pytest_cov.embed
+
+def test_static_pages():
+    
+    for f in os.listdir('templates'):
+        if f == "template.html" or f == "page.html":
+            continue
+
+        static_file = f.split('.',1)[0]
+    
+        print("Checking presence of method: ", static_file)
+        try:
+            method = getattr(app, static_file)
+            assert True
+        except NotImplementedError:
+            assert False


### PR DESCRIPTION
We need to route an endpoint for each statically defined web page, so
let's check if we have this defined for each html file in template,
except for pages.html and template.html.
