### PR TITLE
tests: test generation of dynamic pages

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-3.0
+import pytest
+
+from app import app as flask_app
+
+@pytest.fixture
+def app():
+    yield flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: GPL-3.0
+import os
+
+def test_index_html(app, client):
+    res = client.get('/index.html')
+    assert res.status_code == 200
+
+
+def test_index_slash(app, client):
+    res = client.get('/')
+    assert res.status_code == 200

--- a/tests/test_page_generation.py
+++ b/tests/test_page_generation.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-3.0
+import os
+
+def test_index(app, client):
+    for f in os.listdir('pages'):
+        if not f.endswith('.md'):
+            continue
+
+        dynamic_file = f.split('.', 1)[0]
+        page = "/" + dynamic_file + ".html"
+        print("Checking presence of: ", page)
+        res = client.get(page)
+        assert res.status_code == 200


### PR DESCRIPTION
Test the generation of routes from the markdown input files stored
under pages.

Currently only the routing is tested, not the contents of the files.

Signed-off-by: Johannes Thumshirn <jth@kernel.org>